### PR TITLE
[BUG] Retain New Line Characters for String Value in Job Edit Form

### DIFF
--- a/app/assets/stylesheets/rocket_job_mission_control/jobs.css
+++ b/app/assets/stylesheets/rocket_job_mission_control/jobs.css
@@ -43,7 +43,6 @@
 	 line-height: 2;
 	 resize: none;
 	 width: 100%;
-	 height: 20em;
 	 padding-top: 5px;
 	 padding-bottom: 5px;
 	 margin-bottom: 4px;

--- a/app/controllers/rocket_job_mission_control/application_controller.rb
+++ b/app/controllers/rocket_job_mission_control/application_controller.rb
@@ -25,6 +25,8 @@ module RocketJobMissionControl
     end
 
     def login
+      return unless Config.authorization_callback
+
       @login ||= begin
         args = instance_exec(&Config.authorization_callback)
         args[:login]

--- a/app/controllers/rocket_job_mission_control/jobs_controller.rb
+++ b/app/controllers/rocket_job_mission_control/jobs_controller.rb
@@ -183,7 +183,7 @@ module RocketJobMissionControl
       slice = @job.input.failed.skip(offset).first
 
       # Converts \r\n line breaks to \n
-      updated_records.each { |record| record.gsub!(/\r\n/, "\n") }
+      updated_records.each { |record| record.gsub(/\r\n/, "\n") }
 
       # Assings modified slice (from the form) back to slice
       slice.records = updated_records

--- a/app/controllers/rocket_job_mission_control/jobs_controller.rb
+++ b/app/controllers/rocket_job_mission_control/jobs_controller.rb
@@ -183,7 +183,7 @@ module RocketJobMissionControl
       slice = @job.input.failed.skip(offset).first
 
       # Converts \r\n line breaks to \n
-      updated_records[0] = updated_records[0].gsub(/\r\n/, "\n")
+      updated_records.each { |record| record.gsub!(/\r\n/, "\n") }
 
       # Assings modified slice (from the form) back to slice
       slice.records = updated_records

--- a/app/controllers/rocket_job_mission_control/jobs_controller.rb
+++ b/app/controllers/rocket_job_mission_control/jobs_controller.rb
@@ -182,6 +182,9 @@ module RocketJobMissionControl
       # Finds specific slice [Array]
       slice = @job.input.failed.skip(offset).first
 
+      # Converts \r\n line breaks to \n
+      updated_records[0] = updated_records[0].gsub(/\r\n/, "\n")
+
       # Assings modified slice (from the form) back to slice
       slice.records = updated_records
 

--- a/app/helpers/rocket_job_mission_control/application_helper.rb
+++ b/app/helpers/rocket_job_mission_control/application_helper.rb
@@ -56,6 +56,14 @@ module RocketJobMissionControl
       values
     end
 
+    def escape(s)
+      s.dump[1..-2]
+    end
+
+    def unescape(s)
+      "\"#{s}\"".undump
+    end
+
     # Returns the editable field as html for use in editing dynamic fields from a Job class.
     def editable_field_html(klass, field_name, value, f)
       # When editing a job the values are of the correct type.
@@ -75,7 +83,7 @@ module RocketJobMissionControl
         if options
           f.select(field_name, options, {include_blank: options.include?(nil), selected: value}, {class: "selectize form-control"})
         else
-          f.text_field(field_name, value: value ? value.gsub(/\n/, '\n') : "", class: "form-control", placeholder: placeholder)
+          f.text_area(field_name, value: value ? value : "", class: "form-control", placeholder: placeholder)
         end
       when "Boolean", "Mongoid::Boolean"
         options = extract_inclusion_values(klass, field_name) || [nil, "true", "false"]

--- a/app/helpers/rocket_job_mission_control/application_helper.rb
+++ b/app/helpers/rocket_job_mission_control/application_helper.rb
@@ -75,7 +75,7 @@ module RocketJobMissionControl
         if options
           f.select(field_name, options, {include_blank: options.include?(nil), selected: value}, {class: "selectize form-control"})
         else
-          f.text_field(field_name, value: value, class: "form-control", placeholder: placeholder)
+          f.text_field(field_name, value: value ? value.gsub(/\n/, '\n') : "", class: "form-control", placeholder: placeholder)
         end
       when "Boolean", "Mongoid::Boolean"
         options = extract_inclusion_values(klass, field_name) || [nil, "true", "false"]

--- a/app/models/rocket_job_mission_control/dirmon_sanitizer.rb
+++ b/app/models/rocket_job_mission_control/dirmon_sanitizer.rb
@@ -43,7 +43,7 @@ module RocketJobMissionControl
           end
           properties[:output_categories] = categories unless categories.empty?
         elsif default_job.public_send(name) != updated_job.public_send(name)
-          properties[name] = value.is_a?(String) ? value.gsub!(/\r\n/, "\n") : value
+          properties[name] = value.is_a?(String) ? value.gsub(/\r\n/, "\n") : value
         end
       end
       properties

--- a/app/models/rocket_job_mission_control/dirmon_sanitizer.rb
+++ b/app/models/rocket_job_mission_control/dirmon_sanitizer.rb
@@ -42,8 +42,8 @@ module RocketJobMissionControl
             categories << props unless props.empty?
           end
           properties[:output_categories] = categories unless categories.empty?
-        else
-          properties[name] = value unless default_job.public_send(name) == updated_job.public_send(name)
+        elsif default_job.public_send(name) != updated_job.public_send(name)
+          properties[name] = value.is_a?(String) ? value.gsub(/\r\n/, "\n") : value
         end
       end
       properties

--- a/app/models/rocket_job_mission_control/dirmon_sanitizer.rb
+++ b/app/models/rocket_job_mission_control/dirmon_sanitizer.rb
@@ -43,7 +43,7 @@ module RocketJobMissionControl
           end
           properties[:output_categories] = categories unless categories.empty?
         elsif default_job.public_send(name) != updated_job.public_send(name)
-          properties[name] = value.is_a?(String) ? value.gsub(/\r\n/, "\n") : value
+          properties[name] = value.is_a?(String) ? value.gsub!(/\r\n/, "\n") : value
         end
       end
       properties

--- a/app/models/rocket_job_mission_control/job_sanitizer.rb
+++ b/app/models/rocket_job_mission_control/job_sanitizer.rb
@@ -28,7 +28,7 @@ module RocketJobMissionControl
 
         case field.type.name
         when "String"
-          value.gsub!(/\r\n/, "\n")
+          value.gsub(/\r\n/, "\n")
         when "Hash"
           begin
             value = value.blank? ? nil : JSON.parse(value)

--- a/app/models/rocket_job_mission_control/job_sanitizer.rb
+++ b/app/models/rocket_job_mission_control/job_sanitizer.rb
@@ -27,6 +27,8 @@ module RocketJobMissionControl
         next unless field&.type
 
         case field.type.name
+        when "String"
+          value.gsub!(/\r\n/, "\n")
         when "Hash"
           begin
             value = value.blank? ? nil : JSON.parse(value)

--- a/app/views/rocket_job_mission_control/jobs/_attributes.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/_attributes.html.erb
@@ -2,6 +2,7 @@
 <div class='row'>
   <div class='col-md-12'>
     <table>
+      <%# All NON (array||hash) values first %>
       <% @attributes.each_pair do |key, value| %>
         <% next if value.is_a?(Array) || value.is_a?(Hash) %>
         <% key = key.to_s.titleize %>
@@ -10,10 +11,12 @@
           <% if value.nil? %>
             <td><label>nil</label></td>
           <% else %>
-            <td><%= value %></td>
+            <td><%= simple_format(value) %></td>
           <% end %>
         </tr>
       <% end %>
+
+      <%# All Array Values %>
       <% @attributes.each_pair do |key, value| %>
         <% next unless value.is_a?(Array) %>
         <% key = key.to_s.titleize %>
@@ -52,6 +55,8 @@
           <% end %>
         <% end %>
       <% end %>
+
+      <%# All Hash Values %>
       <% @attributes.each_pair do |key, value| %>
         <% next unless value.is_a?(Hash) %>
         <% key = key.to_s.titleize %>

--- a/app/views/rocket_job_mission_control/jobs/edit_slice.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/edit_slice.html.erb
@@ -6,9 +6,9 @@
     <%= form_for(:job, url: update_slice_job_path(@job, offset: @offset, error_type: @failure_exception.class_name), method: :patch) do |f| %>
       <% @lines.each_with_index do |line, index| %>
         <% if @line_index == index %>
-          <%= f.text_area :records, :value => line, class: 'input_slices', id: index, multiple: true %>
+          <%= f.text_area :records, value: line, class: 'input_slices', id: index, multiple: true, rows: 14, cols: 10, wrap: "soft" %>
         <% else %>
-          <%= f.hidden_field :records, :value => line, class: 'input_slices', id: index, multiple: true %>
+          <%= f.hidden_field :records, value: line, class: 'input_slices', id: index, multiple: true %>
         <% end %>
       <% end %>
 

--- a/rjmc/db/seeds.rb
+++ b/rjmc/db/seeds.rb
@@ -29,10 +29,12 @@ RocketJob::Jobs::SimpleJob.new(priority: 90).start!
 # KaboomBatchJob with exceptions.
 count = 100
 job   = KaboomBatchJob.new
-job.input_category.slice_size = 1
+job.input_category.serializer = :none
+job.input_category.slice_size = 10
 job.upload do |stream|
-  count.times { |i| stream << "Slice number #{i}" }
+  count.times { |i| stream << "Line number #{i + 1}" }
 end
+
 # Manually run job to get some failures without needing workers.
 while job.input.queued.count.positive?
   begin

--- a/rocketjob_mission_control.gemspec
+++ b/rocketjob_mission_control.gemspec
@@ -3,13 +3,14 @@ $:.push File.expand_path("lib", __dir__)
 require "rocket_job_mission_control/version"
 
 Gem::Specification.new do |s|
-  s.name        = "rocketjob_mission_control"
-  s.version     = RocketJobMissionControl::VERSION
-  s.authors     = ["Michael Cloutier", "Chris Lamb", "Jonathan Whittington", "Reid Morrison"]
-  s.homepage    = "https://rocketjob.io"
-  s.summary     = "Ruby's missing batch system."
-  s.description = "Rocket Job Mission Control is the Web user interface to manage Rocket Job."
-  s.license     = "Apache-2.0"
+  s.name                  = "rocketjob_mission_control"
+  s.version               = RocketJobMissionControl::VERSION
+  s.authors               = ["Michael Cloutier", "Chris Lamb", "Jonathan Whittington", "Reid Morrison"]
+  s.homepage              = "https://rocketjob.io"
+  s.summary               = "Ruby's missing batch system."
+  s.description           = "Rocket Job Mission Control is the Web user interface to manage Rocket Job."
+  s.license               = "Apache-2.0"
+  s.required_ruby_version = ">= 2.5"
 
   s.files      = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]


### PR DESCRIPTION
1. When editing a job the text fields are stripping the \n line breaks due to the field being sanitized in the view and thus losing the value on saving the form. We currently want to retain the line breaks.
2. Set minimum Ruby Version to 2.5
3. Convert \r\n line breaks to \n
4. Remove height for slice text_area fields.
5. Fix Batch Job Seed for proper slice numbering.

Closes #80 