### PR TITLE
add url helper method to DirmonEntriesHelper and ServersHelper to avoid engine_name conflict and  prevent undefined method error when we pass float to simple_format 

### DIFF
--- a/app/helpers/rocket_job_mission_control/dirmon_entries_helper.rb
+++ b/app/helpers/rocket_job_mission_control/dirmon_entries_helper.rb
@@ -11,5 +11,9 @@ module RocketJobMissionControl
       categories.each { |category| return category if category_name == (category["name"] || :main).to_sym }
       nil
     end
+    
+    def rocket_job_mission_control
+      @@rocket_job_mission_control_engine_url_helpers ||= RocketJobMissionControl::Engine.routes.url_helpers
+    end
   end
 end

--- a/app/helpers/rocket_job_mission_control/servers_helper.rb
+++ b/app/helpers/rocket_job_mission_control/servers_helper.rb
@@ -26,5 +26,9 @@ module RocketJobMissionControl
         map[server.state] || "callout-info"
       end
     end
+    
+    def rocket_job_mission_control
+      @@rocket_job_mission_control_engine_url_helpers ||= RocketJobMissionControl::Engine.routes.url_helpers
+    end
   end
 end

--- a/app/views/rocket_job_mission_control/jobs/_attributes.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/_attributes.html.erb
@@ -10,8 +10,10 @@
           <td><label><%= key %>:</label></td>
           <% if value.nil? %>
             <td><label>nil</label></td>
+          <% elsif !value.respond_to?(:to_s)%>
+            <td><label>Invalid Value</label></td>
           <% else %>
-            <td><%= simple_format(value) %></td>
+            <td><%= simple_format(value.to_s) %></td>
           <% end %>
         </tr>
       <% end %>


### PR DESCRIPTION
when the app that mounts the engine uses the `as:` option when calling the mount method, calls to internal rocket_job_mission_control.* url_helpers throw an error