### PR TITLE
[BUG] Make Flash messages Consistent with Bootstrap Key

### DIFF
--- a/app/controllers/rocket_job_mission_control/dirmon_entries_controller.rb
+++ b/app/controllers/rocket_job_mission_control/dirmon_entries_controller.rb
@@ -115,7 +115,7 @@ module RocketJobMissionControl
         @dirmon_entry.enable!
         redirect_to(rocket_job_mission_control.dirmon_entry_path(@dirmon_entry))
       else
-        flash[:alert] = t(:failure, scope: %i[dirmon_entry enable])
+        flash[:danger] = t(:failure, scope: %i[dirmon_entry enable])
         render(:show)
       end
     end
@@ -127,7 +127,7 @@ module RocketJobMissionControl
         @dirmon_entry.disable!
         redirect_to(rocket_job_mission_control.dirmon_entry_path(@dirmon_entry))
       else
-        flash[:alert] = t(:failure, scope: %i[dirmon_entry disable])
+        flash[:danger] = t(:failure, scope: %i[dirmon_entry disable])
         render(:show)
       end
     end
@@ -149,7 +149,7 @@ module RocketJobMissionControl
 
     def find_entry_or_redirect
       unless @dirmon_entry = RocketJob::DirmonEntry.where(id: params[:id]).first
-        flash[:alert] = t(:failure, scope: %i[dirmon_entry find], id: params[:id])
+        flash[:danger] = t(:failure, scope: %i[dirmon_entry find], id: ActionController::Base.helpers.sanitize(params[:id]))
         redirect_to(dirmon_entries_path)
       end
     end

--- a/app/controllers/rocket_job_mission_control/jobs_controller.rb
+++ b/app/controllers/rocket_job_mission_control/jobs_controller.rb
@@ -231,14 +231,14 @@ module RocketJobMissionControl
       offset     = params.fetch(:offset, 0).to_i
 
       unless error_type.present?
-        flash[:notice] = t(:no_errors, scope: %i[job failures])
+        flash[:warning] = t(:no_errors, scope: %i[job failures])
         redirect_to(job_path(@job))
       end
 
       scope = @job.input.failed.where("exception.class_name" => error_type)
       count = scope.count
       unless count.positive?
-        flash[:notice] = t(:no_errors, scope: %i[job failures])
+        flash[:warning] = t(:no_errors, scope: %i[job failures])
         redirect_to(job_path(@job))
       end
 
@@ -281,7 +281,7 @@ module RocketJobMissionControl
 
     def find_job_or_redirect
       unless @job = RocketJob::Job.where(id: params[:id]).first
-        flash[:alert] = t(:failure, scope: %i[job find], id: params[:id])
+        flash[:danger] = t(:failure, scope: %i[job find], id: ActionController::Base.helpers.sanitize(params[:id]))
 
         redirect_to(jobs_path)
       end

--- a/app/controllers/rocket_job_mission_control/servers_controller.rb
+++ b/app/controllers/rocket_job_mission_control/servers_controller.rb
@@ -62,9 +62,9 @@ module RocketJobMissionControl
         RocketJob::Server.destroy_zombies
       elsif VALID_ACTIONS.include?(server_action)
         RocketJob::Subscribers::Server.publish(server_action)
-        flash[:notice] = t(:success, scope: %i[server update_all], action: server_action.to_s)
+        flash[:success] = t(:success, scope: %i[server update_all], action: server_action.to_s)
       else
-        flash[:alert] = t(:invalid, scope: %i[server update_all])
+        flash[:danger] = t(:invalid, scope: %i[server update_all])
       end
 
       # TODO: Refresh the same page it was on
@@ -76,7 +76,7 @@ module RocketJobMissionControl
     def stop
       authorize! :stop, @server
       RocketJob::Subscribers::Server.publish(:stop, server_id: @server.id)
-      flash[:notice] = t(:success, scope: %i[server update_one], action: "stop", name: @server.name)
+      flash[:success] = t(:success, scope: %i[server update_one], action: "stop", name: @server.name)
 
       respond_to do |format|
         format.html { redirect_to servers_path }
@@ -86,7 +86,7 @@ module RocketJobMissionControl
     def destroy
       authorize! :destroy, @server
       @server.destroy
-      flash[:notice] = t(:success, scope: %i[server destroy])
+      flash[:success] = t(:success, scope: %i[server destroy])
 
       respond_to do |format|
         format.html { redirect_to servers_path }
@@ -96,7 +96,7 @@ module RocketJobMissionControl
     def pause
       authorize! :pause, @server
       RocketJob::Subscribers::Server.publish(:pause, server_id: @server.id)
-      flash[:notice] = t(:success, scope: %i[server update_one], action: "pause", name: @server.name)
+      flash[:success] = t(:success, scope: %i[server update_one], action: "pause", name: @server.name)
 
       respond_to do |format|
         format.html { redirect_to servers_path }
@@ -106,7 +106,7 @@ module RocketJobMissionControl
     def resume
       authorize! :resume, @server
       RocketJob::Subscribers::Server.publish(:resume, server_id: @server.id)
-      flash[:notice] = t(:success, scope: %i[server update_one], action: "resume", name: @server.name)
+      flash[:success] = t(:success, scope: %i[server update_one], action: "resume", name: @server.name)
 
       respond_to do |format|
         format.html { redirect_to servers_path }
@@ -140,7 +140,7 @@ module RocketJobMissionControl
 
     def find_server_or_redirect
       unless @server = RocketJob::Server.where(id: params[:id]).first
-        flash[:alert] = t(:failure, scope: %i[server find], id: params[:id])
+        flash[:danger] = t(:failure, scope: %i[server find], id: params[:id])
 
         redirect_to(servers_path)
       end

--- a/app/views/layouts/rocket_job_mission_control/partials/_flash.html.erb
+++ b/app/views/layouts/rocket_job_mission_control/partials/_flash.html.erb
@@ -1,13 +1,13 @@
 <% if flash.present? %>
-  <div class='flash text-center'>
+  <div class="flash text-center">
     <% flash.each do |key, msg| %>
-      <div class='alert alert-<%=key%> alert-dismissable' role='alert'>
-        <button class='close' data-dismiss='alert'>
+      <div class="alert alert-<%=key%> alert-dismissable" role="alert">
+        <button class="close" data-dismiss="alert">
           <span>&times;</span>
         </button>
 
         <% if msg.kind_of? Array %>
-          <ul class='list-unstyled margin-bottom-0'>
+          <ul class="list-unstyled margin-bottom-0">
             <% msg.each do |m| %>
               <li><%= m.html_safe %></li>
             <% end %>

--- a/app/views/rocket_job_mission_control/jobs/view_slice.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/view_slice.html.erb
@@ -23,7 +23,9 @@
           <%= render partial: 'layouts/rocket_job_mission_control/partials/flash' %>
           <br>
         <% end %>
+
         <div class='message' tabindex="<%= index + 1 %>" id="<%= index + 1 %>">
+
         <pre><span>Line: <%= index + 1 %></span><br><br><code><%= line %></code><br><br>
           <% if can?(:edit_slice, @job) %><div class='edit_button'><%= link_to "Edit", edit_slice_job_path(@job, offset: @offset, error_type: @failure_exception.class_name, line_index: index), class: 'btn btn-primary' %></div><% end %><div class='edit_button'> <%= link_to "Back", job_path(@job), class: 'btn btn-warning' %></div>
         </pre>

--- a/test/controllers/rocket_job_mission_control/dirmon_entries_controller_test.rb
+++ b/test/controllers/rocket_job_mission_control/dirmon_entries_controller_test.rb
@@ -60,7 +60,7 @@ module RocketJobMissionControl
           end
 
           it "alerts the user" do
-            assert_equal I18n.t(:failure, scope: %i[dirmon_entry enable]), flash[:alert]
+            assert_equal I18n.t(:failure, scope: %i[dirmon_entry enable]), flash[:danger]
           end
         end
       end
@@ -91,7 +91,7 @@ module RocketJobMissionControl
           end
 
           it "alerts the user" do
-            assert_equal I18n.t(:failure, scope: %i[dirmon_entry disable]), flash[:alert]
+            assert_equal I18n.t(:failure, scope: %i[dirmon_entry disable]), flash[:danger]
           end
         end
       end
@@ -277,7 +277,7 @@ module RocketJobMissionControl
           end
 
           it "adds a flash alert message" do
-            assert_equal I18n.t(:failure, scope: %i[dirmon_entry find], id: 42), flash[:alert]
+            assert_equal I18n.t(:failure, scope: %i[dirmon_entry find], id: 42), flash[:danger]
           end
         end
 

--- a/test/controllers/rocket_job_mission_control/jobs_controller_test.rb
+++ b/test/controllers/rocket_job_mission_control/jobs_controller_test.rb
@@ -65,7 +65,7 @@ module RocketJobMissionControl
             end
 
             it "adds a flash alert message" do
-              assert_equal I18n.t(:failure, scope: %i[job find], id: 42), flash[:alert]
+              assert_equal I18n.t(:failure, scope: %i[job find], id: 42), flash[:danger]
             end
           end
 
@@ -121,7 +121,7 @@ module RocketJobMissionControl
           end
 
           it "adds a flash alert message" do
-            assert_equal I18n.t(:failure, scope: %i[job find], id: 42), flash[:alert]
+            assert_equal I18n.t(:failure, scope: %i[job find], id: 42), flash[:danger]
           end
         end
 
@@ -159,7 +159,7 @@ module RocketJobMissionControl
           end
 
           it "adds a flash alert message" do
-            assert_equal I18n.t(:failure, scope: %i[job find], id: 42), flash[:alert]
+            assert_equal I18n.t(:failure, scope: %i[job find], id: 42), flash[:danger]
           end
         end
 
@@ -189,7 +189,7 @@ module RocketJobMissionControl
           end
 
           it "adds a flash alert message" do
-            assert_equal I18n.t(:failure, scope: %i[job find], id: 42), flash[:alert]
+            assert_equal I18n.t(:failure, scope: %i[job find], id: 42), flash[:danger]
           end
         end
 
@@ -204,7 +204,7 @@ module RocketJobMissionControl
             end
 
             it "notifies the user" do
-              assert_equal I18n.t(:no_errors, scope: %i[job failures]), flash[:notice]
+              assert_equal I18n.t(:no_errors, scope: %i[job failures]), flash[:warning]
             end
           end
 

--- a/test/controllers/rocket_job_mission_control/servers_controller_test.rb
+++ b/test/controllers/rocket_job_mission_control/servers_controller_test.rb
@@ -65,7 +65,7 @@ module RocketJobMissionControl
             end
 
             it "does not display an error message" do
-              assert_nil flash[:alert]
+              assert_nil flash[:danger]
             end
           end
         end
@@ -90,7 +90,7 @@ module RocketJobMissionControl
           end
 
           it "displays a flash message" do
-            assert_equal I18n.t(:success, scope: %i[server destroy]), flash[:notice]
+            assert_equal I18n.t(:success, scope: %i[server destroy]), flash[:success]
           end
 
           it "destroys the server" do
@@ -108,7 +108,7 @@ module RocketJobMissionControl
           end
 
           it "displays a flash message" do
-            assert_equal I18n.t(:failure, scope: %i[server find], id: 999_999), flash[:alert]
+            assert_equal I18n.t(:failure, scope: %i[server find], id: 999_999), flash[:danger]
           end
         end
       end


### PR DESCRIPTION
1. Make bootstrap alert messages standard as danger/warning/success.
2. Fix a Reflected-XSS issue with passing un-sanitized params[:id] into alert message.